### PR TITLE
Fix issue with TYPE_of? methods

### DIFF
--- a/lib/camaraderie/user.rb
+++ b/lib/camaraderie/user.rb
@@ -10,7 +10,7 @@ module Camaraderie
       Camaraderie.membership_types.each do |type|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{type}_of?(organization)
-            !!memberships.admins.where(organization: organization).exists?
+            !!memberships.#{type.pluralize}.where(organization: organization).exists?
           end
         RUBY
       end


### PR DESCRIPTION
There was a small issue with `TYPE_of?`. The only working method was `admin_of?`, others were misleading.

``` ruby
organization = Organization.find(1)
user = User.find(1)

organization.members.create(user: user)
user.member_of?(organization) # => false
```
