### PR TITLE
Allow customization of association class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ First, you have to configure which type of memberships you want. Usually, you’
 
 ```ruby
 Camaraderie.configure do |config|
+  # The different types of memberships (defaults to `['admin']`)
   config.membership_types = %w(admin moderator member)
+
+  # The class name of the organization model (defaults to `'Organization'`)
+  config.organization_class = 'Company'
+
+  # The class name of the user model (defaults to `'User'`)
+  config.user_class = 'Employee'
 end
 ```
 

--- a/lib/camaraderie.rb
+++ b/lib/camaraderie.rb
@@ -13,7 +13,17 @@ module Camaraderie
 
   # Return the allowed membership types
   def self.membership_types
-    @configuration.membership_types
+    @configuration.membership_types.try(:map, &:to_s) || %w(member)
+  end
+
+  # Return the class name to use for the organizations association
+  def self.organization_class
+    @configuration.organization_class.try(:to_s) || 'Organization'
+  end
+
+  # Return the class name to use for the users association
+  def self.user_class
+    @configuration.user_class.try(:to_s) || 'User'
   end
 
   # Return a block that can be injected into a class

--- a/lib/camaraderie/membership.rb
+++ b/lib/camaraderie/membership.rb
@@ -3,8 +3,8 @@ module Camaraderie
     extend ActiveSupport::Concern
     included do
       # Associations
-      belongs_to :user, validate: true
-      belongs_to :organization
+      belongs_to :user, validate: true, class_name: Camaraderie.user_class
+      belongs_to :organization, class_name: Camaraderie.organization_class
 
       # Validations
       validates :user, presence: true

--- a/lib/camaraderie/organization.rb
+++ b/lib/camaraderie/organization.rb
@@ -5,7 +5,7 @@ module Camaraderie
     included do
       # Associations
       has_many :memberships, dependent: :destroy
-      has_many :users, through: :memberships
+      has_many :users, through: :memberships, class_name: Camaraderie.user_class
 
       # Define a method for each type of membership
       #

--- a/lib/camaraderie/user.rb
+++ b/lib/camaraderie/user.rb
@@ -5,7 +5,7 @@ module Camaraderie
     included do
       # Associations
       has_many :memberships, dependent: :destroy
-      has_many :organizations, through: :memberships
+      has_many :organizations, through: :memberships, class_name: Camaraderie.organization_class
 
       Camaraderie.membership_types.each do |type|
         class_eval <<-RUBY, __FILE__, __LINE__ + 1


### PR DESCRIPTION
Associations are still referred to as users and organizations but now we’re able to customize the underlying models.
